### PR TITLE
修复下拉刷新完成的闪烁问题

### DIFF
--- a/iOS/Hummer/Classes/Component/Views/ListView/HMRefreshBaseView.m
+++ b/iOS/Hummer/Classes/Component/Views/ListView/HMRefreshBaseView.m
@@ -170,16 +170,18 @@
 }
 
 - (void)endRefresh {
-    [UIView animateWithDuration:0.25 animations:^{
-        UIEdgeInsets inset = self.scrollView.contentInset;
-        inset.top = 0;
-        self.scrollView.contentInset = inset;
-    }];
-    self.state = HMRefreshTypeNormal;
-    if (self.stateChangedBlock) {
-        self.stateChangedBlock(HMRefreshTypeNormal);
-    }
-    [self layoutContentView];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [UIView animateWithDuration:0.25 animations:^{
+            UIEdgeInsets inset = self.scrollView.contentInset;
+            inset.top = 0;
+            self.scrollView.contentInset = inset;
+        }];
+        self.state = HMRefreshTypeNormal;
+        if (self.stateChangedBlock) {
+            self.stateChangedBlock(HMRefreshTypeNormal);
+        }
+        [self layoutContentView];
+    });
 }
 
 - (void)beginRefresh {


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | 无 <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | 下拉刷新完成时出现的闪烁问题
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
修改前效果：
![Kapture 2021-01-25 at 18 11 57](https://user-images.githubusercontent.com/8399816/105695365-f9e2d100-5f3c-11eb-8441-652ce43eff89.gif)
修改后效果：
![Kapture 2021-01-25 at 18 15 25](https://user-images.githubusercontent.com/8399816/105695436-0e26ce00-5f3d-11eb-8e94-f4070de398b3.gif)

