### PR TITLE
feat: Tenon Store 增加业务线隔离的逻辑

### DIFF
--- a/tenon/packages/global.d.ts
+++ b/tenon/packages/global.d.ts
@@ -1,2 +1,4 @@
 declare var __GLOBAL__: any
 declare var __DEV__: Boolean
+declare const Hummer: any
+declare const Memory:any;

--- a/tenon/packages/tenon-store/src/plugins/hummer.ts
+++ b/tenon/packages/tenon-store/src/plugins/hummer.ts
@@ -1,12 +1,8 @@
-declare const Hummer:any;
-declare const Memory:any;
-export const MemoryStoreKey = 'STORE_MEMORY';
-export const NotifyEvent = 'UPDATE_STORE';
-const randomChars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const id = randomString(8, randomChars);
-import {diff, cloneObject} from './utils/index'
+import {diff, cloneObject, getUUID, getNotifyEventKey, getMemoryKey} from './utils/index'
 import {Operation, OperationType} from './utils/types'
-
+const id = getUUID();
+const MemoryStoreKey = getMemoryKey();
+const NotifyEvent = getNotifyEventKey();
 let cacheData:Record<string, any> = {}; 
 /**
  * 多页面同步数据
@@ -37,6 +33,9 @@ export function createHummerPlugin ({
       Memory.set(MemoryStoreKey, JSON.stringify(state));
       // TODO 限流操作
       let ops = diff(cacheData, state);
+      if(!ops || ops.length === 0){
+        return
+      }
       notifyCenter.triggerEvent(NotifyEvent, {
         eventId: id,
         operations: JSON.stringify(ops)
@@ -55,11 +54,6 @@ function initState(store:any){
   }
 }
 
-function randomString(length = 8, chars: string) {
-  var result = '';
-  for (var i = length; i > 0; --i) result += chars[Math.floor(Math.random() * chars.length)];
-  return result;
-}
 
 function setObjectValue(ob:any, keys:Array<string>, value: any){
   let temp = ob;

--- a/tenon/packages/tenon-store/src/plugins/utils/index.ts
+++ b/tenon/packages/tenon-store/src/plugins/utils/index.ts
@@ -1,4 +1,6 @@
 import {OperationType, Operation, Operations} from './types'
+export const NAMESPACE = Hummer.env.namespace || '';
+const randomChars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 /**
  * 对象的Diff操作
  * @param left Origin Object
@@ -59,4 +61,23 @@ function isEqual(left:object, right:object):boolean{
 // Common Clone Object
 export function cloneObject(source: object):object{
   return Object.assign({}, source)
+}
+
+export function getUUID(){
+  const id = randomString(8, randomChars); 
+  return id
+}
+
+export function getNotifyEventKey(){
+  return `${NAMESPACE}_UPDATE_STORE`
+}
+
+export function getMemoryKey(){
+  return `${NAMESPACE}_STORE_MEMORY`
+}
+
+function randomString(length = 8, chars: string) {
+  var result = '';
+  for (var i = length; i > 0; --i) result += chars[Math.floor(Math.random() * chars.length)];
+  return result;
 }


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
Tenon Store 增加业务线的隔离逻辑，通过读取 `Hummer.env.namespace`拼接内存的 key 值和通知的事件 key 值，来进行不同namespace 的页面的数据和通知不会相互影响。