### PR TITLE
fix(tenon): 修复 native 组件布尔类型的属性传递问题

### DIFF
--- a/tenon/packages/tenon-vue/src/runtime/nodes/Base.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/Base.ts
@@ -200,7 +200,7 @@ export class Base {
 
     switch(key){
       case 'disabled':
-        this.disabled = value
+        this.disabled = value !== false
         break;
       case 'class': 
         this.updateStyle()

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/input.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/input.ts
@@ -28,15 +28,7 @@ export  class Input extends Base{
     return this.element.focused || false
   }
   set focused(value:Boolean){
-    let flag = value
-    if(typeof value === 'string'){
-      if(value === 'true'){
-        flag = true
-      }else if(value === 'false'){
-        flag = false
-      }
-    }
-    this.element.focused = flag
+    this.element.focused = value !== false
   }
 
   // 占位提示文本

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/scroller.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/scroller.ts
@@ -12,9 +12,6 @@ export class Scroller extends Base{
   }
   _setAttribute(key:string, value: any){
     switch(key){
-      case 'disabled':
-        this.disabled = value
-        break;
       case 'scroll-direction':
         if(value === 'horizontal' &&  this.element instanceof ScrollerComponent){
           // 属性切换时，滚动插件需要重新生命；同时元素渲染从children一次向上，这个时候element children已经赋值

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/switch.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/switch.ts
@@ -13,7 +13,7 @@ export class Switch extends Base{
     return this.element.checked
   }
   set value(value: Boolean){
-    this.element.checked = value
+    this.element.checked = value !== false
   }
 
   set onColor(value: string){

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/textarea.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/textarea.ts
@@ -27,15 +27,7 @@ export class TextArea extends Base{
     return this.element.focused || false
   }
   set focused(value:Boolean){
-    let flag = value
-    if(typeof value === 'string'){
-      if(value === 'true'){
-        flag = true
-      }else if(value === 'false'){
-        flag = false
-      }
-    }
-    this.element.focused = flag
+    this.element.focused = value !== false
   }
 
   // 占位提示文本


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #146 <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | No <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->

Vue 和 H5 的布尔类型传递规则是存在且不等于 false 即为 true
补充完善布尔类型的规则

`disabled` 属性由 base 拦截，组件无法执行 disabled 的 case，所以删除组件的 disabled 设置代码
