### PR TITLE
fix(tenon): 同时支持驼峰和横杠相连的属性传递

### DIFF
--- a/examples/tenon-vue/src/component-button/app.vue
+++ b/examples/tenon-vue/src/component-button/app.vue
@@ -12,13 +12,13 @@
     <view class="demo-item">
       <text class="demo-item-title">Button With Disabled</text>
       <view class="demo-box">
-        <button class="btn" :disabled="true" :disabled-style="disabledStyle"  @tap="handleClickBtn('Button With Disabled')">Button</button>
+        <button class="btn" disabled :disabled-style="disabledStyle"  @tap="handleClickBtn('Button With Disabled')">Button</button>
       </view>
     </view>
      <view class="demo-item">
       <text class="demo-item-title">Button With PressedStyle</text>
       <view class="demo-box">
-        <button class="btn" :pressed-style="pressedStyle"  @click="handleClickBtn('Button With PressedStyle')">Button</button>
+        <button class="btn" :pressedStyle="pressedStyle"  @click="handleClickBtn('Button With PressedStyle')">Button</button>
       </view>
     </view>
   </view>

--- a/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
+++ b/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
@@ -1,10 +1,17 @@
 import { NodeTransform, NodeTypes} from '@vue/compiler-core'
+import { camelize } from '@hummer/tenon-utils'
 // 处理内置组件的参数和事件
 export const transformProps:NodeTransform = (node:any) => {
   return function(){
     if(node.type === NodeTypes.ELEMENT){
       const { props } = node
       props.forEach((p: any) => {
+        if(p.type === NodeTypes.ATTRIBUTE) {
+            p.name = camelize(p.name)
+        }
+        if(p.type === NodeTypes.DIRECTIVE && p.name === 'bind') {
+            p.arg.content = camelize(p.arg.content)
+        }
         if(p.type === NodeTypes.DIRECTIVE && p.name === 'on' && p.arg.content === 'click') {
             p.arg.content = 'tap'
         }

--- a/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
+++ b/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
@@ -11,7 +11,7 @@ export const transformProps:NodeTransform = (node:any) => {
           if(p.type === NodeTypes.ATTRIBUTE) {
             p.name = camelize(p.name)
           }
-          if(p.type === NodeTypes.DIRECTIVE && p.name === 'bind') {
+          if(p.type === NodeTypes.DIRECTIVE && p.name === 'bind' && p.arg && p.arg.isStatic) {
               p.arg.content = camelize(p.arg.content)
           }
         }

--- a/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
+++ b/tenon/packages/tenon-compiler/src/transforms/transformProps.ts
@@ -1,16 +1,19 @@
 import { NodeTransform, NodeTypes} from '@vue/compiler-core'
-import { camelize } from '@hummer/tenon-utils'
+import { camelize, isNativeTags } from '@hummer/tenon-utils'
 // 处理内置组件的参数和事件
 export const transformProps:NodeTransform = (node:any) => {
   return function(){
-    if(node.type === NodeTypes.ELEMENT){
-      const { props } = node
+    const { props, tag, type } = node
+    if(type === NodeTypes.ELEMENT){
       props.forEach((p: any) => {
-        if(p.type === NodeTypes.ATTRIBUTE) {
+        //FIXME: 自定义ex-开头的组件也支持驼峰设置的时候删除isNativeTags判断
+        if(isNativeTags(tag)) {
+          if(p.type === NodeTypes.ATTRIBUTE) {
             p.name = camelize(p.name)
-        }
-        if(p.type === NodeTypes.DIRECTIVE && p.name === 'bind') {
-            p.arg.content = camelize(p.arg.content)
+          }
+          if(p.type === NodeTypes.DIRECTIVE && p.name === 'bind') {
+              p.arg.content = camelize(p.arg.content)
+          }
         }
         if(p.type === NodeTypes.DIRECTIVE && p.name === 'on' && p.arg.content === 'click') {
             p.arg.content = 'tap'

--- a/tenon/packages/tenon-utils/src/utils/index.ts
+++ b/tenon/packages/tenon-utils/src/utils/index.ts
@@ -40,4 +40,14 @@ export function makeMapByArr(list:any, expectedLowerCase:Boolean =false){
   return expectedLowerCase ? (val:any) => !!map[val.toLowerCase()] : (val:any) => !!map[val]
 }
 
+const camelizeRE = /-(\w)/g
+/**
+ * 将字符串转换成驼峰命名方式
+ * @param str 待判断的字符串 test-data
+ * @returns 返回转换后的字符串 testData
+ */
+export function camelize(str:string){
+  return str.replace(camelizeRE, (_, c) => (c ? c.toUpperCase() : ''))
+}
+
 export * from './api'

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/button.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/button.ts
@@ -39,10 +39,10 @@ export class Button extends Base{
       case 'disabled':
         this.disabled = value
         break;
-      case 'disabled-style':
+      case 'disabledStyle':
         this.disabledStyle = value
         break;
-      case 'pressed-style':
+      case 'pressedStyle':
         this.pressedStyle = value
         break;
       default:

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/input.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/input.ts
@@ -71,10 +71,10 @@ export  class Input extends Base{
       case 'type':
         this.type = value
         break;
-      case 'max-length':
+      case 'maxLength':
         this.maxLength = value
         break;
-      case 'return-key-type':
+      case 'returnKeyType':
         this.returnKeyType = value
         break;
       default:

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/scroller.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/scroller.ts
@@ -12,7 +12,7 @@ export class Scroller extends Base{
   }
   _setAttribute(key:string, value: any){
     switch(key){
-      case 'scroll-direction':
+      case 'scrollDirection':
         if(value === 'horizontal' &&  this.element instanceof ScrollerComponent){
           // 属性切换时，Scroller组件需要重新声明，同时进行 Children的重新赋值
           let scroller = new HorizontalScroller() as any

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/switch.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/switch.ts
@@ -37,13 +37,13 @@ export class Switch extends Base{
       case 'value':
         this.value = value
         break;
-      case 'open-color':
+      case 'openColor':
         this.onColor = value
         break;
-      case 'close-color':
+      case 'closeColor':
         this.offColor = value
         break;
-      case 'thumb-color':
+      case 'thumbColor':
         this.thumbColor = value
         break;
       default:

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/text.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/text.ts
@@ -30,7 +30,7 @@ export class Text extends Base{
 
   _setAttribute(key:string, value: any){
     switch(key){
-      case 'rich-text':
+      case 'richText':
         this.richText = value
         break;
       default:

--- a/tenon/packages/tenon-vue/src/runtime/nodes/components/textarea.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/components/textarea.ts
@@ -76,10 +76,10 @@ export class TextArea extends Base{
       case 'type':
         this.type = value
         break;
-      case 'max-length':
+      case 'maxLength':
         this.maxLength = value
         break;
-      case 'return-key-type':
+      case 'returnKeyType':
         this.returnKeyType = value
         break;
       case 'rows':


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #146  <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | YES
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->

构建的时候把内部组件的属性都转换成驼峰的方式，不处理事件的驼峰，
然后基础组件属性判断都改为驼峰方式

只修改内部组件的驼峰，自定义组件将保持传递

这样比较接近Vue原生写法同时之前驼峰和横杠相连的属性传递，