### PR TITLE
fix: 修复 border 缩写与预期不符的问题

### DIFF
--- a/examples/tenon-vue/src/common/assets/css/common.less
+++ b/examples/tenon-vue/src/common/assets/css/common.less
@@ -1,23 +1,4 @@
-.warning-text {
-  color: red;
-  padding: .2rem 0.2rem;
-  margin: 0 .2rem;
-}
-
-.operation-container {
-  display: flex;
-  justify-content: space-between;
-}
-.btn {
-  flex: 1;
-  margin: 0 0.2rem;
-  height: 0.8rem;
-  text-align: center;
-  color: white;
-  background: #fa9153;
-  border-radius: 10px;
-}
-
+// Common Css
 .page {
   background-color: #eeeeee;
   margin-bottom: 0.5rem;
@@ -60,6 +41,7 @@
 .operation-container {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
 }
 .btn {
   flex: 1;
@@ -68,5 +50,6 @@
   text-align: center;
   color: white;
   background: #fa9153;
-  border-radius: 10px;
+  border-radius: .1rem;
+  margin-top: .1rem;
 }

--- a/examples/tenon-vue/src/style-basic/app.vue
+++ b/examples/tenon-vue/src/style-basic/app.vue
@@ -9,70 +9,74 @@
           <text class="item-title-text">盒模型</text>
         </view>
         <view class="item-container">
-          <view class="box-item">
+          <view class="box-single-item">
             <view class="box-content">
               <text>Box Content</text>
             </view>
           </view>
         </view>
       </view>
+      <view class="demo-item">
+        <view class="item-title">
+          <text class="item-title-text">Border</text>
+        </view>
+        <view class="item-container">
+          <view class="box-item border-item" :style="borderStyle">
+            <text>{{ borderStyle }}</text>
+          </view>
+        </view>
+        <view class="operation-container">
+          <button class="btn" @tap="updateBorderStyle('border:none')">
+            border: none
+          </button>
+          <button class="btn" @tap="updateBorderStyle('border:0')">
+            border: 0
+          </button>
+          <button class="btn" @tap="updateBorderStyle('border: dotted red')">
+            border: dotted red
+          </button>
+          <button class="btn" @tap="updateBorderStyle('border:.1rem dashed red')">
+            border: .1rem dashed red
+          </button>
+        </view>
+      </view>
     </view>
-
   </view>
 </template>
 <style lang="less" scoped>
-.page {
+@import "../common/assets/css/common.less";
+.box-single-item {
+  width: 4rem;
+  height: 4rem;
   background-color: #eeeeee;
-  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border: 0.2rem solid blue;
 }
-.demo-header {
-  padding: 0.2rem 0;
-  background-color: #fa9153;
-}
-.demo-title {
-  font-size: 0.36rem;
+.box-content {
+  background-color: red;
   width: 100%;
-  text-align: center;
-  color: white;
+  height: 100%;
 }
-.demo-container {
-  margin-top: 0.2rem;
+.border-item {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  justify-content: center;
+  border: 0.05rem solid black;
 }
-.demo-item {
-  background-color: #ffffff;
-  width: 100%;
-  margin-bottom: 0.2rem;
-  padding: 0.2rem 0;
-}
-.item-title {
-  text-align: center;
-}
-.item-title-text {
-  text-align: center;
-  font-size: 0.28rem;
-}
-.item-container {
-  margin-top: 0.2rem;
-}
-  .box-item{
-    width: 4rem;
-    height: 4rem;
-    background-color: #eeeeee;
-    padding: 0.5rem;
-    border: 0.2rem solid blue;
-  }
-  .box-content{
-    background-color: red;
-    width: 100%;
-    height: 100%;
-  }
 </style>
 
 <script>
 export default {
-  data(){
+  data() {
     return {
-    }
-  }
-}
+      borderStyle: "",
+    };
+  },
+  methods: {
+    updateBorderStyle(style) {
+      this.borderStyle = style;
+    },
+  },
+};
 </script>

--- a/tenon/packages/tenon-utils/src/style/common/utils.ts
+++ b/tenon/packages/tenon-utils/src/style/common/utils.ts
@@ -8,6 +8,14 @@ export enum Keyword {
   AUTO = "auto"
 }
 
+export enum BorderStyle {
+  NONE = 'none',
+  SOLID = 'solid',
+  DASHED = 'dashed',
+  DOTTED = 'dotted'
+}
+
+
 /**
  * 判断是否是 Number 类型
  * @param num<number> 待判断的 Number 类型 
@@ -33,7 +41,19 @@ export function isWidth(width: Width):Boolean{
  * @returns Boolean 是否是 Length 类型
  */
 export function isLength(length: any):Boolean{
-  let lengthReg = /[\d\.]+(%|rem|hm|cpx)?$/
-  return length && length.test(lengthReg)
+  let lengthReg = /[\d\.]+(%|rem|hm|cpx|px|vw|vh)?$/
+  return lengthReg.test(length)
 }
 
+
+
+/**
+ * 判断是否是 BorderStyle 类型
+ * @param value 
+ * @returns 
+ */
+ export function isBorderStyle(value: string):Boolean{
+  return [BorderStyle.NONE,BorderStyle.DASHED,BorderStyle.DOTTED, BorderStyle.SOLID].findIndex((borderStyle:BorderStyle) => {
+    return value === borderStyle
+  }) !== -1
+}

--- a/tenon/packages/tenon-utils/src/style/transformer/border.ts
+++ b/tenon/packages/tenon-utils/src/style/transformer/border.ts
@@ -1,10 +1,6 @@
+import {isBorderStyle, isLength, Style} from '../common/utils'
 import {extend} from '../../index'
 const attrs = ["border","border-left", "border-right", "border-top", "border-bottom"]
-const borderBreakReadius = /([\.\w]+)\s+(\w+)\s+([\w#\s\(,\.\)]+)/
-interface Style {
-  attr: string,
-  value: string
-}
 
 export function transformBorder(style:Record<string, string>):Record<string, string>{
   let tempStyle:Record<string, string> = {
@@ -15,33 +11,33 @@ export function transformBorder(style:Record<string, string>):Record<string, str
       return;
     }else {
       delete tempStyle[attr]
-      tempStyle = extend(transformBorderStyle({
-        attr: attr,
-        value: style[attr]
-      }), tempStyle)
+      tempStyle = extend(transformBorderStyle(attr, style[attr]), tempStyle)
     }
   })
   return tempStyle
 }
 
 /**
- * 转换Border Style
- * @param value string
+ * 转换Border Style，进行聚合属性的拆解
+ * 参考 MDN 文档：https://developer.mozilla.org/en-US/docs/Web/CSS/border
+ * The border property may be specified using one, two, or three of the values listed below. The order of the values does not matter.
+ * @param attr 待拆解的属性
+ * @param value 待拆解的属性值
  * ex.borderLeft: 1px solid #eee; borderWidth: 1px; borderStyle: solid; borderColor: #eee;
+ * ex.border: none; borderStyle: none;
  */
-function transformBorderStyle({
-  attr,
-  value
-}:Style){
-  let matches = value.match(borderBreakReadius)
-  // 如果不符合标准Border写法，返回为空
-  if(!matches){
-    return {}
+function transformBorderStyle(attr:string, borderValue:string){
+  let values = borderValue.trim().split(/\s+/);
+  let tempStyle:Style = {};
+  for(let i=0,len=values.length; i<len; i++){
+    if(isBorderStyle(values[i])){
+      tempStyle[attr + "-style"] = values[i]
+    }else if(isLength(values[i])){
+      tempStyle[attr + "-width"] = values[i]
+    }else{
+      tempStyle[attr + "-color"] = values[i]
+    }
   }
-  let [,borderWidth, borderStyle, borderColor] = matches
-  return {
-    [attr+"-width"]: borderWidth,
-    [attr+"-style"]: borderStyle,
-    [attr+"-color"]: borderColor,
-  }
+  return tempStyle
 }
+


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | Fixes: #136 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
修复Tenon 中 border 样式缩写与预期不符的问题。

现在border属性对标 MDN Border 规范。