### PR TITLE
fix(iOS): longPress use begin state as recognizer

### DIFF
--- a/iOS/Hummer/Classes/Component/Views/View/UIView+HMEvent.m
+++ b/iOS/Hummer/Classes/Component/Views/View/UIView+HMEvent.m
@@ -211,7 +211,7 @@ HM_EXPORT_METHOD(removeEventListener, hm_removeEvent:withListener:)
         
         return;
     } else if ([gesture isKindOfClass:UILongPressGestureRecognizer.class]) {
-        if (gesture.state != UIGestureRecognizerStateEnded) {
+        if (gesture.state != UIGestureRecognizerStateBegan) {
             // 只有 end 才会回调
             return;
         }
@@ -219,7 +219,7 @@ HM_EXPORT_METHOD(removeEventListener, hm_removeEvent:withListener:)
         [callbackArray enumerateObjectsUsingBlock:^(HMBaseValue * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             [obj callWithArguments:@[@{
                                          @"type": @"longPress",
-                                         @"state": @(UIGestureRecognizerStateEnded),
+                                         @"state": @(UIGestureRecognizerStateBegan),
                                          @"timestamp": @(timestamp),
                                          @"position": @{
                                                  @"x": @(location.x),


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | No <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->