### PR TITLE
修复 Tenon 中 longPress 事件无法使用的问题

### DIFF
--- a/examples/tenon-vue/src/main/assets/menu.js
+++ b/examples/tenon-vue/src/main/assets/menu.js
@@ -96,6 +96,14 @@ export const Style = {
     name: '布局样式'
   }]
 }
+export const Event = {
+  title: '事件篇',
+  items: [{
+    url: './event.js',
+    name: '基础事件'
+  }]
+}
+
 export const Other = {
   title: '其它',
   items: [{
@@ -105,4 +113,4 @@ export const Other = {
 }
 
 
-export const Menu =  [GrammarMenu, ComponentMenu, HighComponent, Style, Animation, Plugin, Other]
+export const Menu =  [GrammarMenu, ComponentMenu, HighComponent, Style, Animation,Event, Plugin, Other]

--- a/tenon/packages/tenon-react/src/events/index.ts
+++ b/tenon/packages/tenon-react/src/events/index.ts
@@ -17,9 +17,15 @@ export function isEventProp(propName: string){
  * 获取标准的事件名称
  * @param name 
  */
-export function getEventName(name: string){
-  return name.slice(2).toLowerCase()
+export function getEventName(rawName: string){
+  let eventName = rawName.slice(2).toLowerCase()
+  if(eventName === 'longpress'){
+    eventName = "longPress"
+  }
+  return eventName
 }
+
+
 
 
 export * from './listener'

--- a/tenon/packages/tenon-vue/src/runtime/handlers/events.ts
+++ b/tenon/packages/tenon-vue/src/runtime/handlers/events.ts
@@ -3,6 +3,7 @@ import {
   ComponentInternalInstance
 } from '@vue/runtime-core'
 
+const LongPress = 'longpress'
 interface Invoker extends EventListener {
   value: EventValue
 }
@@ -17,7 +18,7 @@ export function patchEvents(
   nextValue: EventValue | null,
   instance: ComponentInternalInstance | null = null
 ){
-  const event = rawName.slice(2).toLowerCase()
+  const event = getStaticEventName(rawName)
   const value = nextValue
   const invoker = prevValue && prevValue.invoker
   if(nextValue && value){
@@ -57,4 +58,12 @@ export function addEventListener(el:Base, event: string, handler: EventListener)
 }
 export function removeEventListener(el:Base, event: string, handler: EventListener){
   el.removeEventListener(event, handler)
+}
+
+export function getStaticEventName(rawName: string){
+  let eventName = rawName.slice(2).toLowerCase()
+  if(eventName === LongPress){
+    eventName = "longPress"
+  }
+  return eventName
 }


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #206 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | No <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->