### PR TITLE
fix(devtools):1.修复工具栏不显示问题 2.隐藏函数树

### DIFF
--- a/iOS/Hummer/Classes/DevTools/HMDevToolsEntryView.m
+++ b/iOS/Hummer/Classes/DevTools/HMDevToolsEntryView.m
@@ -47,6 +47,7 @@ static const CGFloat HMDevToolsWindowEntryViewSize = 50.f;
     if (![currentVC.childViewControllers containsObject:self.toolsVC]) {
         [currentVC addChildViewController:self.toolsVC];
         [currentVC.view addSubview:self.toolsVC.view];
+        self.toolsVC.view.frame = currentVC.view.frame;
     }
     if (![currentVC.view.subviews containsObject:self]) {
         CGRect tagetFrame = currentVC.view.frame;

--- a/iOS/Hummer/Classes/DevTools/HMDevToolsViewController.m
+++ b/iOS/Hummer/Classes/DevTools/HMDevToolsViewController.m
@@ -75,10 +75,7 @@
             return hierarchyVC;
         }],
         [HMDevToolsMenuItem menuItemWithTitle:@"函数树" container:^UIViewController * _Nonnull(HMJSContext * _Nonnull context) {
-            HMDevPageInfoViewController *pageVC = HMDevPageInfoViewController.new;
-            pageVC.context = context;
-            pageVC.textType = HMDevToolsTextTypeCallerTree;
-            return pageVC;
+            return UIViewController.new;
         }],
         [HMDevToolsMenuItem menuItemWithTitle:@"性能" container:^UIViewController * _Nonnull(HMJSContext * _Nonnull context) {
             return UIViewController.new;


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          |  Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | Yes <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
1.修复工具栏在某些情况不显示
2.移除函数树，需要重新设计