### PR TITLE
Tenon Vue Style Refactor

### DIFF
--- a/tenon/packages/tenon-vue/src/runtime/nodes/Base.ts
+++ b/tenon/packages/tenon-vue/src/runtime/nodes/Base.ts
@@ -1,6 +1,8 @@
 import {styleDynamicTransformer} from '@hummer/tenon-utils'
 import {setCacheNode,handleFixedNodeByStyle,removeChildWithFixed} from '../helper/fixed-helper'
 import {handleAnimation, Animation} from '../helper/animation-helper'
+import {getClassStyle} from '../../utils/style'
+
 let __view_id = 0;
 export class Base {
   public _scopedId:string|null = null
@@ -52,23 +54,8 @@ export class Base {
 
   public updateStyle(){
     if(!this._scopedId) return
-    let CSSOM : any,
-        elementStyle = {}
-    if(!(CSSOM = (<any>__GLOBAL__).CSSOM)) return
-    const className = this.getAttribute('class') || ''
-    const scopedRuleSet = CSSOM.hasOwnProperty(this._scopedId) ? CSSOM[this._scopedId].classMap : new Map()
-    const classList = className.split(/\s/)
-    
-    classList.forEach((item: any) => {
-      if(item){
-        let globalStyleArr = CSSOM['global'].classMap.get(item) || []
-        globalStyleArr = globalStyleArr.map((item : any) => item?.style)
-        let scopeStylesArr = scopedRuleSet.get(item) || []
-        scopeStylesArr = scopeStylesArr.map((item : any) => item?.style)
-        // 将元素总样式、全局变量、scoped变量按照顺序合并
-        elementStyle = Object.assign({}, elementStyle, ...globalStyleArr, ...scopeStylesArr)
-      }
-    })
+    let className = this.getAttribute('class')
+    let elementStyle = getClassStyle(this, className, true, this._scopedId)
     if(Object.keys(elementStyle).length > 0){
       this.setStyle(elementStyle)
     }

--- a/tenon/packages/tenon-vue/src/utils/style.ts
+++ b/tenon/packages/tenon-vue/src/utils/style.ts
@@ -1,10 +1,11 @@
-export enum MatchType{
+export enum MatchType {
   Class,
   ID,
-  Attr
+  Attr,
+  Tag,
 }
 export interface RuleNode {
-  selector: string,
+  selector: any,
   relation: string,
   matchType: MatchType
 }
@@ -57,9 +58,17 @@ const collectStyleGroup = function(ruleSet: RuleSet, group: string){
     key && ruleList.forEach((rule:RuleNode) => {
       if(rule){
         let selectorMap = __GLOBAL__.CSSOM[group][key]
-        let styleList = selectorMap.get(rule.selector) || []
+        let selectorKey = ""
+        // 版本兼容，兼容老的 Tenon Style Loader: selector a；
+        if(typeof rule.selector === 'object'){
+          // new selector
+          selectorKey = rule.selector?.value
+        }else {
+          selectorKey = rule.selector
+        }
+        let styleList = selectorMap.get(selectorKey) || []
         styleList.push(rule)
-        __GLOBAL__.CSSOM[group][key].set(rule.selector, styleList)
+        __GLOBAL__.CSSOM[group][key].set(selectorKey, styleList)
       }
     })
   })

--- a/tenon/packages/tenon-vue/src/utils/style.ts
+++ b/tenon/packages/tenon-vue/src/utils/style.ts
@@ -1,3 +1,9 @@
+import { Base } from "src/runtime"
+
+export interface Style{
+  [key:string]:string
+}
+
 export enum MatchType {
   Class,
   ID,
@@ -67,5 +73,50 @@ const collectStyleGroup = function(ruleSet: RuleSet, group: string){
   })
 }
 
+export const getClassStyle = function(instance: Base, className: string = '',scoped:Boolean = false, scopedId?:string){
+  let elementStyle = {}
+  const classList = className.split(/\s/)
+  
+  classList.forEach((item: any) => {
+    if(!item){return}
+    let globalStyleArr = getGlobalStyle(MatchType.Class, item)
+    let scopeStylesArr:Array<Style> = []
+    if(scoped && scopedId){
+      scopeStylesArr = getScopedStyle(MatchType.Class, item, scopedId)
+    }
+    // 将元素总样式、全局变量、scoped变量按照顺序合并
+    elementStyle = Object.assign({}, elementStyle, ...globalStyleArr, ...scopeStylesArr)
+  })
+  return elementStyle
+}
 
+function getGlobalStyle(type: MatchType, key:string):Array<Style>{
+  let styles:Array<Style> = []
+  switch(type){
+    case MatchType.Class:
+      styles =  __GLOBAL__.CSSOM['global'].classMap.get(key) || []
+      break;
+    default:
+      break;
+  }
+  return styles.map((item:any) => {
+    return item?.style
+  })
+}
 
+function getScopedStyle(type:MatchType, key:string, scopedId: string):Array<Style>{
+  let styles:Array<Style> = []
+  const {CSSOM} = __GLOBAL__
+  if(CSSOM[scopedId]){
+    switch(type){
+      case MatchType.Class:
+        styles =  CSSOM[scopedId].classMap.get(key) || []
+        break;
+      default:
+        break;
+    }
+  }
+  return styles.map((item:any) => {
+    return item?.style
+  })
+}

--- a/tenon/packages/tenon-vue/src/utils/style.ts
+++ b/tenon/packages/tenon-vue/src/utils/style.ts
@@ -58,14 +58,7 @@ const collectStyleGroup = function(ruleSet: RuleSet, group: string){
     key && ruleList.forEach((rule:RuleNode) => {
       if(rule){
         let selectorMap = __GLOBAL__.CSSOM[group][key]
-        let selectorKey = ""
-        // 版本兼容，兼容老的 Tenon Style Loader: selector a；
-        if(typeof rule.selector === 'object'){
-          // new selector
-          selectorKey = rule.selector?.value
-        }else {
-          selectorKey = rule.selector
-        }
+        let selectorKey = rule.selector
         let styleList = selectorMap.get(selectorKey) || []
         styleList.push(rule)
         __GLOBAL__.CSSOM[group][key].set(selectorKey, styleList)


### PR DESCRIPTION
重构 Tenon Vue 样式模块，将 Style 处理从 Base基类中抽离，为了将来的 Tenon React 复用做铺垫。