### PR TITLE
fix(Android): napi_get_cb_info memory overlap

### DIFF
--- a/android/hummer-core/src/main/jni/napi/hummer/JSEngine.cpp
+++ b/android/hummer-core/src/main/jni/napi/hummer/JSEngine.cpp
@@ -13,8 +13,9 @@ static NAPIValue invoke(NAPIEnv globalEnv, NAPICallbackInfo info) {
     size_t argc;
     napi_get_cb_info(globalEnv, info, &argc, nullptr, nullptr, nullptr);
     NAPIValue argv[argc];
-    int32_t callbackId;
-    napi_get_cb_info(globalEnv, info, &argc, argv, nullptr, (void **)&callbackId);
+    void *data;
+    napi_get_cb_info(globalEnv, info, &argc, argv, nullptr, &data);
+    int32_t callbackId = (int32_t) (size_t) data;
 
     JNIEnv* env = JNI_GetEnv();
     jobjectArray params = nullptr;


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | No <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
修复使用 napi_get_cb_info 时候的内存重叠问题