### PR TITLE
feat(tenon-store): add custom cache key

### DIFF
--- a/tenon/packages/tenon-store/src/plugins/hummer.ts
+++ b/tenon/packages/tenon-store/src/plugins/hummer.ts
@@ -1,22 +1,35 @@
 import {diff, cloneObject, getUUID, getNotifyEventKey, getMemoryKey,stringify, parseJson, getMemoryByKey, setMemoryByKey} from './utils/index'
 import {Operation, OperationType} from './utils/types'
 const id = getUUID();
-const MemoryStoreKey = getMemoryKey();
-const NotifyEvent = getNotifyEventKey();
 let cacheData:Record<string, any> = {}; 
+
+/**
+ * Hummer Store 插件配置项
+ */
+interface HummerPluginOptions {
+  /**
+   * 自定义的存储key
+   * 默认会通过 Hummer.env.namespace 生成对应的 Memory 存储 key
+   * 当应用中存在多个 Store 时，可以通过该缓存插件传入自定义的 key 做存储区分
+   */
+  store_key?: string
+}
 /**
  * 多页面同步数据
  * @param param Options
  */
 export function createHummerPlugin ({
-  
-} = {}) {
+  store_key
+}: HummerPluginOptions = {}) {
+  const MemoryStoreKey = getMemoryKey(store_key);
+  const NotifyEvent = getNotifyEventKey(store_key);
+
   return (store:any) => {
     // 初始化数据
-    initState(store)
+    initState(store, MemoryStoreKey)
     // 注册通知
     let notifyCenter =  Hummer.notifyCenter
-    notifyCenter.addEventListener(NotifyEvent, ({eventId, operations}:any) => {
+    notifyCenter.addEventListener(NotifyEvent, ({eventId, operations}: any) => {
       if(eventId === id){
         return
       }
@@ -45,7 +58,7 @@ export function createHummerPlugin ({
   }
 }
 
-function initState(store:any){
+function initState(store: any, MemoryStoreKey: string){
   let newData = getMemoryByKey(MemoryStoreKey);
   if(newData){
     newData = parseJson(newData);

--- a/tenon/packages/tenon-store/src/plugins/utils/index.ts
+++ b/tenon/packages/tenon-store/src/plugins/utils/index.ts
@@ -69,12 +69,12 @@ export function getUUID(){
   return id
 }
 
-export function getNotifyEventKey(){
-  return `${NAMESPACE}_UPDATE_STORE`
+export function getNotifyEventKey(customKey?: string){
+  return `${customKey || NAMESPACE}_UPDATE_STORE`
 }
 
-export function getMemoryKey(){
-  return `${NAMESPACE}_STORE_MEMORY`
+export function getMemoryKey(customKey?: string){
+  return `${customKey || NAMESPACE}_STORE_MEMORY`
 }
 
 function randomString(length = 8, chars: string) {


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | No <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->
对于 `tenon-store` 的 Hummer plugin 添加新`store_key` 配置，可通过传入该配置自定义在 `Memory` 中的存储位置。
适用于应用中存在多个自定义 Store 时使用。