### PR TITLE
fix(iOS): ex-list set scrollDirection horizontal, scrollToPosition me…

### DIFF
--- a/iOS/Hummer/Classes/Component/Views/ListView/HMRecycleListView.m
+++ b/iOS/Hummer/Classes/Component/Views/ListView/HMRecycleListView.m
@@ -522,9 +522,16 @@ HMBaseValue *(^__executeBlock)(HMFuncCallback, NSArray *) = ^(HMFuncCallback cal
     }
     
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:0];
-    [self scrollToItemAtIndexPath:indexPath
-                 atScrollPosition:UICollectionViewScrollPositionTop
-                         animated:YES];
+    //根据UICollectionViewScrollDirection设置不同的UICollectionViewScrollPosition
+    if(_direction == UICollectionViewScrollDirectionHorizontal){
+        [self scrollToItemAtIndexPath:indexPath
+                     atScrollPosition:UICollectionViewScrollPositionLeft
+                             animated:YES];
+    }else{
+        [self scrollToItemAtIndexPath:indexPath
+                     atScrollPosition:UICollectionViewScrollPositionTop
+                             animated:YES];
+    }
 }
 
 - (void)scrollToX:(HMBaseValue *)xValue Y:(HMBaseValue *)yValue {


### PR DESCRIPTION
修复iOS端，使用ex-list组件，设置横向滚动时，scrollToPosition方法不生效的问题。
原因：scrollToPosition的端上的原生方法中，使用collectionView的scrollToItemAtIndexPath: atScrollPosition: animated:方法时，UICollectionViewScrollPosition传递的是固定的UICollectionViewScrollPositionTop，导致了横向滚动时不生效。
解决办法：根据当前的滚动方向，设置不同的UICollectionViewScrollPosition。（查看源码，设置滚动方向时，更新了_direction，所以根据_direction可以直接取到当前的滚动方向）
仍然存在的问题：
1、进入页面首次使用scrollToPosition时，跳转的位置有偏差（目前来看取消动画可以解决，但是体验不好，后续继续看一下）
2、目前默认设置横向滚动时，设置了collectionView的pagingEnabled。但是横向滚动的大多数场景，是不需要分页的，这块可以删除默认的写法，增加pagingEnabled接口，让开发者可以自己控制是否使用分页
3、安卓和iOS双端的scrollToPosition效果以及ex-list中item的布局效果不一致