### PR TITLE
fix(iOS): SocketRocket old version will call webSocket:didReceiveMessage: forcely

### DIFF
--- a/iOS/Hummer/Classes/Component/WebSocket/HMWebSocket.m
+++ b/iOS/Hummer/Classes/Component/WebSocket/HMWebSocket.m
@@ -104,7 +104,15 @@ HM_EXPORT_METHOD(send, send:)
 
 /// MARK: - SRWebSocketDelegate
 
-// - webSocket:didReceiveMessage: 被废弃
+- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message {
+    if ([message isKindOfClass:NSString.class]) {
+        [self webSocket:webSocket didReceiveMessageWithString:message];
+    } else if ([message isKindOfClass:NSData.class]) {
+        [self webSocket:webSocket didReceiveMessageWithData:message];
+    } else {
+        NSAssert(NO, @"webSocket:didReceiveMessage: pass unknown message object");
+    }
+}
 
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessageWithString:(NSString *)string {
     HMAssertMainQueue();


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | No <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->