### PR TITLE
issue-405 fix 解决DefaultHttpAdapter中timeout字段单位不一致的问题

### DIFF
--- a/android/hummer-sdk/src/main/java/com/didi/hummer/adapter/http/impl/DefaultHttpAdapter.java
+++ b/android/hummer-sdk/src/main/java/com/didi/hummer/adapter/http/impl/DefaultHttpAdapter.java
@@ -104,8 +104,8 @@ public class DefaultHttpAdapter implements IHttpAdapter {
         // build client & set timeout
         OkHttpClient client = httpClient.newBuilder()
                 .connectTimeout(timeout, TimeUnit.MILLISECONDS)
-                .readTimeout(timeout, TimeUnit.SECONDS)
-                .writeTimeout(timeout, TimeUnit.SECONDS)
+                .readTimeout(timeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                 .build();
 
         // set url
@@ -148,8 +148,8 @@ public class DefaultHttpAdapter implements IHttpAdapter {
         // build client & set timeout
         OkHttpClient client = httpClient.newBuilder()
                 .connectTimeout(timeout, TimeUnit.MILLISECONDS)
-                .readTimeout(timeout, TimeUnit.SECONDS)
-                .writeTimeout(timeout, TimeUnit.SECONDS)
+                .readTimeout(timeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                 .build();
 
         // set url


### PR DESCRIPTION
（Android）Fixes #405 
Android Request组件，DefaultHttpAdapter的get和post方法中，对于OkHttpClient的connectTimeout、readTimeout、writeTimeout超时时间设置单位不统一的问题。