### PR TITLE
fix(iOS): 修复 iOS项目集成时，yoga 库缺少的问题

### DIFF
--- a/Hummer.podspec
+++ b/Hummer.podspec
@@ -84,10 +84,11 @@ Hummer is a dynamic solution for client.
     }
     ss.framework = 'JavaScriptCore'
     ss.dependency 'SocketRocket', '~> 0.1'
+    ss.dependency "Yoga", "~> 1.14"
   end
 
   s.subspec "RN" do |ss|
-    ss.dependency "yoga"
+    ss.dependency "Yoga"
     ss.dependency 'Hummer/Core'
   end
 


### PR DESCRIPTION
<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | NO <!-- 移除 (`) 引用符号并在议题号前写 "Fixes" 来关联议题 -->
| Patch: Bug Fix?          | YES
| Major: Breaking Change?  | NO
| Minor: New Feature?      | NO <!-- 选择当前拉取请求的性质 -->
| Tests Added + Pass?      | NO <!-- 是否已经添加了单元测试并且通过了所有单元测试 -->

<!-- 请在下面尽可能详细地描述您的更改 -->

已有的 iOS 项目在使用 cocopods 集成 Hummer 时，default_subspec 为 “Core”， 但是该 subspec 却没有声明依赖 “Yoga”，导致 Xcode 编译不通过。
Xcode 版本：Version 13.3 (13E113)
CocoaPods 版本：1.11.3
集成 Hummer 的代码：
`  pod 'Hummer', :git => 'git@github.com:didi/Hummer.git', :branch => 'master'
`

When integrating Hummer to an existing project, its default_subspec is Core, whose dependencies does not include Yoga, which will cause build fail to compile after pod install success.
Xcode Version: 13.3
CocoaPods Version：1.11.3
How I integrated Hummer to my project:
`  pod 'Hummer', :git => 'git@github.com:didi/Hummer.git', :branch => 'master'
`
