### PR TITLE
fix(iOS): add missing `onopen` call to WebSocket

### DIFF
--- a/iOS/Hummer/Classes/Component/WebSocket/HMWebSocket.m
+++ b/iOS/Hummer/Classes/Component/WebSocket/HMWebSocket.m
@@ -133,6 +133,7 @@ HM_EXPORT_METHOD(send, send:)
     }
     [webSocketSet addObject:self];
     self.context.webSocketSet = webSocketSet;
+    self.onOpen ? self.onOpen(@[@{}]) : nil;
 }
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error {


### PR DESCRIPTION
fix #419

<!-- 对于议题的引用：添加逗号分隔的[结束词](https://help.github.com/articles/closing-issues-via-commit-messages)列表，接下来是这个拉取请求修复的议题号。（如果正确的话，在预览的时候会出现下划线） -->
| Q                        | A <!-- （可以使用 emoji 👍） -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #419 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Y

<!-- 请在下面尽可能详细地描述您的更改 -->